### PR TITLE
Handle multiline code blocks

### DIFF
--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -47,7 +47,7 @@ let id = 0;
 const SHELL_SCRIPT_PATTERN = /^>>\s+(?<script>.*)$/gm;
 const COMMAND_PATTERN = /(?<commandPrefix>\(command:[\w+\.]+\?)(?<params>\[[^\]]+\])/gm;
 const TOUR_REFERENCE_PATTERN = /(?:\[(?<linkTitle>[^\]]+)\])?\[(?=\s*[^\]\s])(?<tourTitle>[^\]#]+)?(?:#(?<stepNumber>\d+))?\](?!\()/gm;
-const CODE_FENCE_PATTERN = /```[^\n]+\n(.+)\n```/gm;
+const CODE_FENCE_PATTERN = /```[^\n]+\n(.+)\n```/gms;
 
 export function generatePreviewContent(content: string) {
   return content


### PR DESCRIPTION
Adds `s` flag to `CODE_FENCE_PATTERN` regex.
This allows to match multiline code blocks and add `Insert Code` button below them. 

Fixes #155