### PR TITLE
Set webpack to run verbose

### DIFF
--- a/package.json
+++ b/package.json
@@ -659,7 +659,7 @@
   "scripts": {
     "build": "webpack --mode production",
     "vscode:prepublish": "npm run build",
-    "watch": "webpack --mode development --watch",
+    "watch": "webpack --mode development --watch --info-verbosity verbose",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "package": "vsce package"
   },


### PR DESCRIPTION
This allows the VS Code task system to process webpack's output. 🥳