### PR TITLE
Enable functionality to start the default tour as soon as it's discovered

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,10 @@
         "command": "codetour.viewNotebook",
         "title": "View Notebook",
         "category": "CodeTour"
+      },
+      {
+        "command": "codetour._startTourOnActivation",
+        "title": "Start Tour on Activation"
       }
     ],
     "menus": {
@@ -340,6 +344,10 @@
         },
         {
           "command": "codetour.viewNotebook",
+          "when": "false"
+        },
+        {
+          "command": "codetour._startTourOnActivation",
           "when": "false"
         }
       ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,12 +3,13 @@
 
 import * as vscode from "vscode";
 import { initializeApi } from "./api";
+import { EXTENSION_NAME } from "./constants";
 import { initializeGitApi } from "./git";
 import { registerLiveShareModule } from "./liveShare";
 import { registerNotebookProvider } from "./notebook";
 import { registerPlayerModule } from "./player";
 import { registerRecorderModule } from "./recorder";
-import { promptForTour } from "./store/actions";
+import { promptForTour, startDefaultTour } from "./store/actions";
 import { discoverTours } from "./store/provider";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -17,9 +18,22 @@ export async function activate(context: vscode.ExtensionContext) {
   registerLiveShareModule();
   registerNotebookProvider();
 
+  let skipTourPrompt = false;
+  const skipTourPromptCommand = vscode.commands.registerCommand(
+    `${EXTENSION_NAME}._startTourOnActivation`,
+    () => skipTourPrompt = true
+  );
+
   if (vscode.workspace.workspaceFolders) {
     await discoverTours();
-    promptForTour(context.globalState);
+
+    skipTourPromptCommand.dispose();
+
+    if (skipTourPrompt) {
+      startDefaultTour();
+    } else {
+      promptForTour(context.globalState);
+    }
 
     initializeGitApi();
   }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -162,20 +162,31 @@ export async function promptForTour(
         "Start CodeTour"
       )
     ) {
-      const primaryTour =
-        tours.find(tour => tour.isPrimary) ||
-        tours.find(tour => tour.title.match(/^#?1\s+-/));
-
-      if (primaryTour) {
-        startCodeTour(primaryTour, 0, workspaceRoot, false, undefined, tours);
-        return true;
-      } else {
-        return selectTour(tours, workspaceRoot);
-      }
+      startDefaultTour(workspaceRoot, tours);
     }
   }
 
   return false;
+}
+
+export async function startDefaultTour(
+  workspaceRoot: Uri = getWorkspaceKey(),
+  tours: CodeTour[] = store.tours
+): Promise<boolean> {
+  if (tours.length === 0) {
+    return false;
+  }
+
+  const primaryTour =
+    tours.find(tour => tour.isPrimary) ||
+    tours.find(tour => tour.title.match(/^#?1\s+-/));
+
+  if (primaryTour) {
+    startCodeTour(primaryTour, 0, workspaceRoot, false, undefined, tours);
+    return true;
+  } else {
+    return selectTour(tours, workspaceRoot);
+  }
 }
 
 export async function exportTour(tour: CodeTour) {


### PR DESCRIPTION
This command, when run right on startup, allows the default tour to begin immediately, instead of prompting the user.

This was hard to do since:

- There's no way to read context from an extension
- There's no way to dismiss an active notification

I hope this approach is OK. Basically everything works as before except that if the `codetour._startTourOnActivation` _internal_ command gets run right on activation, the user won't be prompted at all, but instead the default tour will just start. If more than one primary tour is found, then the user is prompted. 