### PR TITLE
Custom Tour Directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
           "type": "boolean",
           "default": true,
           "description": "Specifies whether or not to show tour markers in the editor gutter."
+        },
+        "codetour.customTourLocation": {
+          "type": "string",
+          "default": null,
+          "description": "Specifies a custom location to use when discovering tours."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
           "default": true,
           "description": "Specifies whether or not to show tour markers in the editor gutter."
         },
-        "codetour.customTourLocation": {
+        "codetour.customTourDirectory": {
           "type": "string",
           "default": null,
           "description": "Specifies a custom location to use when discovering tours."

--- a/src/store/provider.ts
+++ b/src/store/provider.ts
@@ -22,6 +22,13 @@ const TOUR_CONTEXT = {
   isWeb: vscode.env.uiKind === vscode.UIKind.Web
 };
 
+const customDirectory = vscode.workspace
+  .getConfiguration("codetour")
+  .get("promptForWorkspaceTours", null);
+if (customDirectory) {
+  SUB_TOUR_DIRECTORIES.push(customDirectory);
+}
+
 export async function discoverTours(): Promise<void> {
   const tours = await Promise.all(
     vscode.workspace.workspaceFolders!.map(async workspaceFolder => {

--- a/src/store/provider.ts
+++ b/src/store/provider.ts
@@ -24,7 +24,7 @@ const TOUR_CONTEXT = {
 
 const customDirectory = vscode.workspace
   .getConfiguration("codetour")
-  .get("customTourLocation", null);
+  .get("customTourDirectory", null);
 if (customDirectory) {
   SUB_TOUR_DIRECTORIES.push(customDirectory);
 }

--- a/src/store/provider.ts
+++ b/src/store/provider.ts
@@ -24,7 +24,7 @@ const TOUR_CONTEXT = {
 
 const customDirectory = vscode.workspace
   .getConfiguration("codetour")
-  .get("promptForWorkspaceTours", null);
+  .get("customTourLocation", null);
 if (customDirectory) {
   SUB_TOUR_DIRECTORIES.push(customDirectory);
 }


### PR DESCRIPTION
This PR fixes #173.

I added a setting `codetour.customTourLocation` and logic to push the value into the `SUB_TOUR_DIRECTORIES` set. The intention is that I can add a value in `.vscode/settings.json` to enable tour discovery in any path needed.