### PR TITLE
Restores terminal focus capability to view attribute

### DIFF
--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -191,7 +191,7 @@ const VIEW_COMMANDS = new Map([
   ["problems", "workbench.panel.markers"],
   ["scm", "workbench.view.scm"],
   ["search", "workbench.view.search"],
-  ["terminal", "workbench.panel.terminal"]
+  ["terminal", "terminal.focus"]
 ]);
 
 function getPreviousTour(): CodeTour | undefined {


### PR DESCRIPTION
This fixes at least part of #198 by restoring the terminal VIEW_COMMANDS to function.

There are a few others that are also not working.