### PR TITLE
Fix performance issue with watching sub-tour directories

### DIFF
--- a/src/store/provider.ts
+++ b/src/store/provider.ts
@@ -150,7 +150,7 @@ async function discoverSubTours(workspaceUri: vscode.Uri): Promise<CodeTour[]> {
 vscode.workspace.onDidChangeWorkspaceFolders(discoverTours);
 
 const watcher = vscode.workspace.createFileSystemWatcher(
-  `**/{${SUB_TOUR_DIRECTORIES.join(",")}/**/*.tour`
+  `**/{${SUB_TOUR_DIRECTORIES.join(",")}}/**/*.tour`
 );
 
 watcher.onDidChange(discoverTours);


### PR DESCRIPTION
Closes #207 Closes #216

The pattern for the file system watcher has a typo which is causing it to watch all files in the workspace folders instead of only the `.tour` files.

This PR fixes the typo by closing the group condition.

For testing, I am switching between two branches in a large git repo which changes >1000 files which are not `.tour` files.

Without the fix whenever I switch branches I see very high cpu usage of the Extension Host with many calls to `discoverTours`:
<img width="1586" alt="Screen Shot 2022-01-27 at 3 48 44 PM" src="https://user-images.githubusercontent.com/5288285/151462572-0f38a32e-b1a8-4739-abf6-ff4abe306cdb.png">

With the fix whenever I switches branches there is no longer high CPU usage and no calls to `discoverTours` (since no .tour files changed):
<img width="1498" alt="Screen Shot 2022-01-27 at 3 49 14 PM" src="https://user-images.githubusercontent.com/5288285/151462762-fb912c3e-d3b7-4859-89c4-b0dc06e4b333.png">

