### PR TITLE
feat: add custom icon

### DIFF
--- a/src/player/tree/nodes.ts
+++ b/src/player/tree/nodes.ts
@@ -112,6 +112,27 @@ export class CodeTourStepNode extends TreeItem {
     } else if (progress.isComplete(tour, stepNumber)) {
       // @ts-ignore
       this.iconPath = completeIcon;
+    } else if (step.icon) {
+      if (step.icon.startsWith('.')) {
+        const resourceRoot = workspaceRoot
+          ? workspaceRoot
+          : getWorkspaceUri(tour);
+          
+          this.iconPath = getFileUri(step.icon, resourceRoot);
+      } else {
+        try {
+          const uri = Uri.parse(step.icon, true);
+          
+          this.iconPath = uri;
+        } catch {
+          const data = step.icon.split(',');
+          if (data.length > 1) {
+            this.iconPath = new ThemeIcon(data[0], new ThemeColor(data[1]));
+          } else {
+            this.iconPath = new ThemeIcon(data[0]);
+          }
+        }
+      }
     } else if (step.directory) {
       this.iconPath = ThemeIcon.Folder;
     } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,6 +12,7 @@ export interface CodeTourStepPosition {
 export interface CodeTourStep {
   title?: string;
   description: string;
+  icon?: string;
 
   // If any of the following are set, then only
   // one of them can be, since these properties


### PR DESCRIPTION
This PR allows to customize the icon of a step.

The icon can be:
- an url: `"icon": "https://cdn.jsdelivr.net/gh/vsls-contrib/code-tour/images/icon-small.png"`
- a relative file: `"icon": "./icon.png"` (relative to the workspace)
- a tuple containing the icon id and, optionally, the color id: `"icon": "error,terminal.ansiCyan"` from
  - https://code.visualstudio.com/api/references/icons-in-labels#icon-listing
  - https://code.visualstudio.com/api/references/theme-color

It should fix #236.