### PR TITLE
feat: read codetour files from regular files and symbolic links

### DIFF
--- a/src/store/provider.ts
+++ b/src/store/provider.ts
@@ -112,6 +112,8 @@ async function readTourDirectory(uri: vscode.Uri): Promise<CodeTour[]> {
         const fileUri = vscode.Uri.joinPath(uri, file);
         if (type === vscode.FileType.File) {
           return readTourFile(fileUri);
+        } else if (type === vscode.FileType.SymbolicLink) {
+          return readTourFile(fileUri)
         } else {
           return readTourDirectory(fileUri);
         }


### PR DESCRIPTION
First of all, thank you for this amazing project!

This is a request to add the ability for the extension to read symlink files so that codetour files can exist outside of the repository

Any feedback is appreciated