### PR TITLE
[Fix] Make it possible to run multiple async VS Code commands in the same step

### DIFF
--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -397,9 +397,9 @@ async function renderCurrentStep() {
   }
 
   if (step.commands) {
-    step.commands.forEach(async command => {
+    for (const command of step.commands) {
       let name = command,
-        args: any[] = [];
+      args: any[] = [];
 
       if (command.includes("?")) {
         const parts = command.split("?");
@@ -413,7 +413,7 @@ async function renderCurrentStep() {
         // Silently fail, since it's unclear if the
         // command was critical to the step or not.
       }
-    });
+    }
   }
 }
 

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -408,10 +408,10 @@ async function renderCurrentStep() {
       }
 
       try {
+        console.log("Executing command", name, JSON.stringify(args));
         await commands.executeCommand(name, ...args);
-      } catch {
-        // Silently fail, since it's unclear if the
-        // command was critical to the step or not.
+      } catch (e) {
+        window.showErrorMessage(`An error has occurred: ${e}`);
       }
     }
   }


### PR DESCRIPTION
[We're currently using a `forEach` loop][1]  to run all VS Code commands that we pass in a single Code Tour step. 

After testing this with our [codespaces-codeql repo][2], we've found that if multiple commands are async, only the first one gets triggered successfully. 

This is because `forEach` loops [won't await promises][3] and will instead throw them away. 

If we want to run our commands in sequence, it's recommended that we use a modern `for ... of` loop instead.

[1]: https://github.com/microsoft/codetour/blob/e7018e228c64f9dde061af56217927159cd42950/src/player/index.ts#L400
[2]: https://github.com/github/codespaces-codeql
[3]: https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop