### PR TITLE
Update schema for `view` to match code implementation

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -37,24 +37,33 @@
             "description": "Directory path (relative to the workspace root) that the step is associated with."
           },
           "view": {
-            "type": "string",
-            "enum": [
-              "debug",
-              "debug:breakpoints",
-              "debug:callstack",
-              "debug:variables",
-              "debug:watch",
-              "explorer",
-              "extensions",
-              "extensions:disabled",
-              "extensions:enabled",
-              "output",
-              "problems",
-              "scm",
-              "search",
-              "terminal"
-            ],
-            "description": "The view ID (e.g. gistpad.gists) that this step is associated with."
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "debug",
+                  "debug:breakpoints",
+                  "debug:callstack",
+                  "debug:variables",
+                  "debug:watch",
+                  "explorer",
+                  "extensions",
+                  "extensions:disabled",
+                  "extensions:enabled",
+                  "output",
+                  "problems",
+                  "scm",
+                  "search",
+                  "terminal"
+                ],
+                "description": "The view ID (e.g. gistpad.gists) that this step is associated with."
+              },
+              {
+                "type": "string",
+                "minLength": 1,
+                "description": "The view ID (e.g. gistpad.gists) that this step is associated with."
+              }
+            ]
           },
           "uri": {
             "type": "string",


### PR DESCRIPTION
Fixes https://github.com/microsoft/codetour/issues/279.

You can link a tour step to _any_ view (as implemented [here](https://github.com/microsoft/codetour/blob/02662423cc6bbf18c9cf750f9b9b86408d52f457/src/player/index.ts#L386-L388) in the code). However, the schema seemed too restrictive and only allowed a fixed list of views. I've added more information to the linked issue! 🙇🏽‍♀️ 

This PR expands the schema to allow anything in that `enum` as well as any custom view. Alternative suggestion: we could delete the `enum` altogether, but that would make those "well-known" views less visible 💜

